### PR TITLE
remove bad data added to export

### DIFF
--- a/btec.php
+++ b/btec.php
@@ -132,7 +132,7 @@ $groups = array();
 if ($showgroups) {
     $groups = report_componentgrades_get_user_groups($course->id);
 }
-report_componentgrades_add_data($sheet, $students, $gradinginfopos, 'btec', $groups);
+report_componentgrades_add_data($sheet, $students, $gradinginfopos, 'btec', $groups, $showgroups);
 
 $workbook->close();
 

--- a/guide.php
+++ b/guide.php
@@ -116,7 +116,7 @@ if ($showgroups) {
     $groups = report_componentgrades_get_user_groups($course->id);
 }
 
-report_componentgrades_add_data($sheet, $students, $gradinginfopos, 'guide', $groups);
+report_componentgrades_add_data($sheet, $students, $gradinginfopos, 'guide', $groups, $showgroups);
 
 $workbook->close();
 

--- a/locallib.php
+++ b/locallib.php
@@ -105,10 +105,8 @@ function report_componentgrades_add_header(MoodleExcelWorkbook $workbook, Moodle
         $sheet->write_string(HEADINGSROW, $col, get_string('studentid', 'report_componentgrades'), $format2);
         $col++;
     }
-    if (get_config('report_componentgrades', 'showgroups')) {
-        if ($showgroups) {
-            $sheet->write_string(HEADINGSROW, $col++, get_string('groups'), $format2);
-        }
+    if ($showgroups) {
+        $sheet->write_string(HEADINGSROW, $col++, get_string('groups'), $format2);
     }
     $sheet->set_column(0, $col, 10); // Set column widths to 10.
 
@@ -170,7 +168,7 @@ function report_componentgrades_process_data(array $students, array $data) {
  * @param array $groups - user group information (optional).
  * @return void
  */
-function report_componentgrades_add_data(MoodleExcelWorksheet $sheet, array $students, $gradinginfopos, $method, $groups = null) {
+function report_componentgrades_add_data(MoodleExcelWorksheet $sheet, array $students, $gradinginfopos, $method, $groups = null, $showgroups = false) {
     // Actual data.
     $row = 5;
     foreach ($students as $student) {
@@ -182,13 +180,11 @@ function report_componentgrades_add_data(MoodleExcelWorksheet $sheet, array $stu
         if (get_config('report_componentgrades', 'showstudentid')) {
              $sheet->write_string($row, $col++, $student->idnumber);
         }
-        if (get_config('report_componentgrades', 'showgroups')) {
-            if (!is_null($groups)) {
-                if (isset($groups[$student->userid])) {
-                    $sheet->write_string($row, $col++, implode(', ', $groups[$student->userid]));
-                } else {
-                    $sheet->write_string($row, $col++, 'empty');
-                }
+        if ($showgroups) {
+            if (!is_null($groups) && isset($groups[$student->userid])) {
+                $sheet->write_string($row, $col++, implode(', ', $groups[$student->userid]));
+            } else {
+                $sheet->write_string($row, $col++, 'empty');
             }
         }
 

--- a/rubric.php
+++ b/rubric.php
@@ -118,7 +118,7 @@ $groups = array();
 if ($showgroups) {
     $groups = report_componentgrades_get_user_groups($course->id);
 }
-$row = report_componentgrades_add_data($sheet, $students, $gradinginfopos, 'rubric', $groups);
+report_componentgrades_add_data($sheet, $students, $gradinginfopos, 'rubric', $groups, $showgroups);
 
 $workbook->close();
 


### PR DESCRIPTION
The issue comes from the header function correctly using `$showgroups` which checks both the `showgroups` config setting, but also checks the course groupmode. However the data function previously 

The inconsistency in the header and data functions causes the issue. I have passed in `$showgroups` to the generating fucntions to make it consistent with the header, there should be no more edge cases now as it all simply uses `$showgroups`. If if is false there can not be a header or data, and if its true there will always be a header and data.

It was added in #15  and fixes #20

I also removed the `$row` variable being used on line 121 of `rubic.php`, it is not used anywhere, and now makes it consistant with guide and btec files.